### PR TITLE
Feat: code split svgs for smaller initial bundle

### DIFF
--- a/src/components/ThresholdsAssistant.tsx
+++ b/src/components/ThresholdsAssistant.tsx
@@ -3,7 +3,7 @@ import { GrafanaTheme2, ThresholdsConfig } from '@grafana/data';
 import { Alert, Icon, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
-export function ThresholdsAssistant({ thresholds }: { thresholds?: ThresholdsConfig }) {
+export default function ThresholdsAssistant({ thresholds }: { thresholds?: ThresholdsConfig }) {
   const validSteps = validateThresholds(thresholds!);
   const styles = useStyles2(getStyles);
   return (

--- a/src/components/TrafficLightDefault.tsx
+++ b/src/components/TrafficLightDefault.tsx
@@ -1,16 +1,8 @@
 import React from 'react';
 import { TEST_IDS } from '../constants';
-import { Colors } from 'types';
+import { TrafficLightProps } from 'types';
 
-type TrafficLightProps = {
-  colors: Colors[];
-  bgColor?: string;
-  emptyColor?: string;
-  onClick?: React.MouseEventHandler<SVGSVGElement>;
-  horizontal: boolean;
-};
-
-export function TrafficLightDefault({
+export default function TrafficLightDefault({
   colors = [],
   bgColor = 'grey',
   emptyColor = 'black',

--- a/src/components/TrafficLightDynamic.tsx
+++ b/src/components/TrafficLightDynamic.tsx
@@ -1,16 +1,8 @@
 import React from 'react';
-import { Colors } from 'types';
+import { TrafficLightProps } from 'types';
 import { clamp } from 'utils/utils';
 
-type TrafficLightProps = {
-  colors: Colors[];
-  bgColor?: string;
-  emptyColor?: string;
-  onClick?: React.MouseEventHandler<SVGSVGElement>;
-  horizontal: boolean;
-};
-
-export function TrafficLightDynamic({
+export default function TrafficLightDynamic({
   colors = [],
   bgColor = 'grey',
   emptyColor = 'black',

--- a/src/components/TrafficLightPanel.tsx
+++ b/src/components/TrafficLightPanel.tsx
@@ -1,15 +1,48 @@
-import { GrafanaTheme2, PanelProps } from '@grafana/data';
-import React from 'react';
+import { GrafanaTheme2, PanelProps, ThresholdsConfig } from '@grafana/data';
+import React, { lazy, Suspense } from 'react';
 import { DataLinksContextMenu, useTheme2 } from '@grafana/ui';
-import { LightsDataResultStatus, LightsDataValues, TrafficLightOptions, TrafficLightStyles } from '../types';
+import {
+  LightsDataResultStatus,
+  LightsDataValues,
+  TrafficLightOptions,
+  TrafficLightProps,
+  TrafficLightStyles,
+} from '../types';
 import { useLightsData } from 'hooks/useLightsData';
 import { calculateRowsAndColumns } from 'utils/utils';
 import { TEST_IDS } from '../constants';
-import { ThresholdsAssistant } from './ThresholdsAssistant';
-import { TrafficLightDefault } from './TrafficLightDefault';
-import { TrafficLightRounded } from './TrafficLightRounded';
-import { TrafficLightSideLights } from './TrafficLightSideLights';
-import { TrafficLightDynamic } from './TrafficLightDynamic';
+
+const LazyThresholdsAssistant = lazy(() => import('./ThresholdsAssistant'));
+const LazyTrafficLightDefault = lazy(() => import('./TrafficLightDefault'));
+const LazyTrafficLightRounded = lazy(() => import('./TrafficLightRounded'));
+const LazyTrafficLightSideLights = lazy(() => import('./TrafficLightSideLights'));
+const LazyTrafficLightDynamic = lazy(() => import('./TrafficLightDynamic'));
+
+const ThresholdsAssistant = ({ thresholds }: { thresholds?: ThresholdsConfig }) => (
+  <Suspense fallback={null}>
+    <LazyThresholdsAssistant thresholds={thresholds} />
+  </Suspense>
+);
+const TrafficLightDefault = (props: TrafficLightProps) => (
+  <Suspense fallback={null}>
+    <LazyTrafficLightDefault {...props} />
+  </Suspense>
+);
+const TrafficLightRounded = (props: TrafficLightProps) => (
+  <Suspense fallback={null}>
+    <LazyTrafficLightRounded {...props} />
+  </Suspense>
+);
+const TrafficLightSideLights = (props: TrafficLightProps) => (
+  <Suspense fallback={null}>
+    <LazyTrafficLightSideLights {...props} />
+  </Suspense>
+);
+const TrafficLightDynamic = (props: TrafficLightProps) => (
+  <Suspense fallback={null}>
+    <LazyTrafficLightDynamic {...props} />
+  </Suspense>
+);
 
 interface TrafficLightPanelProps extends PanelProps<TrafficLightOptions> {}
 

--- a/src/components/TrafficLightRounded.tsx
+++ b/src/components/TrafficLightRounded.tsx
@@ -1,16 +1,8 @@
 import React from 'react';
 import { TEST_IDS } from '../constants';
-import { Colors } from 'types';
+import { TrafficLightProps } from 'types';
 
-type TrafficLightProps = {
-  colors: Colors[];
-  bgColor?: string;
-  emptyColor?: string;
-  onClick?: React.MouseEventHandler<SVGSVGElement>;
-  horizontal: boolean;
-};
-
-export function TrafficLightRounded({
+export default function TrafficLightRounded({
   colors = [],
   bgColor = 'grey',
   emptyColor = 'black',

--- a/src/components/TrafficLightSideLights.tsx
+++ b/src/components/TrafficLightSideLights.tsx
@@ -1,16 +1,8 @@
 import React from 'react';
 import { TEST_IDS } from '../constants';
-import { Colors } from 'types';
+import { TrafficLightProps } from 'types';
 
-type TrafficLightProps = {
-  colors: Colors[];
-  bgColor?: string;
-  emptyColor?: string;
-  onClick?: React.MouseEventHandler<SVGSVGElement>;
-  horizontal: boolean;
-};
-
-export function TrafficLightSideLights({
+export default function TrafficLightSideLights({
   colors = [],
   bgColor = 'grey',
   emptyColor = 'black',

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,14 @@ export enum SortOptions {
   Desc = 'descending',
 }
 
+export type TrafficLightProps = {
+  colors: Colors[];
+  bgColor?: string;
+  emptyColor?: string;
+  onClick?: React.MouseEventHandler<SVGSVGElement>;
+  horizontal: boolean;
+};
+
 export interface TrafficLightOptions {
   minLightWidth: number;
   showValue: boolean;


### PR DESCRIPTION
This PR lazy loads the different traffic light svgs based on traffic light "style" settings.