### PR TITLE
feat: add stack light style

### DIFF
--- a/provisioning/dashboards/panels.json
+++ b/provisioning/dashboards/panels.json
@@ -43,12 +43,12 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
-                "value": 33
+                "color": "orange",
+                "value": 0
               },
               {
                 "color": "green",
-                "value": 66
+                "value": 33
               }
             ]
           }
@@ -61,23 +61,26 @@
         "x": 0,
         "y": 0
       },
-      "id": 6,
+      "id": 27,
       "options": {
+        "customColors": {
+          "enabled": false
+        },
         "horizontal": false,
         "layoutMode": "grid",
         "minLightWidth": 75,
         "reverseColors": false,
         "seriesCountSize": "sm",
-        "showLegend": true,
+        "showLegend": false,
         "showSeriesCount": false,
         "showTrend": false,
-        "showValue": false,
+        "showValue": true,
         "singleRow": false,
         "sortLights": "none",
         "style": "default",
         "text": "Default value of text input option"
       },
-      "pluginVersion": "0.5.2",
+      "pluginVersion": "1.0.0",
       "targets": [
         {
           "datasource": {
@@ -88,7 +91,7 @@
           "seriesCount": 1
         }
       ],
-      "title": "Traffic Light",
+      "title": "Traffic Light with value",
       "type": "heywesty-trafficlight-panel"
     },
     {
@@ -127,6 +130,9 @@
       },
       "id": 11,
       "options": {
+        "customColors": {
+          "enabled": false
+        },
         "horizontal": false,
         "layoutMode": "grid",
         "minLightWidth": 75,
@@ -138,10 +144,10 @@
         "showValue": true,
         "singleRow": false,
         "sortLights": "none",
-        "style": "rounded",
+        "style": "default",
         "text": "Default value of text input option"
       },
-      "pluginVersion": "0.5.2",
+      "pluginVersion": "1.0.0",
       "targets": [
         {
           "datasource": {
@@ -185,12 +191,15 @@
       },
       "gridPos": {
         "h": 12,
-        "w": 4,
+        "w": 3,
         "x": 6,
         "y": 0
       },
       "id": 12,
       "options": {
+        "customColors": {
+          "enabled": false
+        },
         "horizontal": false,
         "layoutMode": "grid",
         "minLightWidth": 75,
@@ -202,10 +211,10 @@
         "showValue": true,
         "singleRow": false,
         "sortLights": "none",
-        "style": "sidelights",
+        "style": "default",
         "text": "Default value of text input option"
       },
-      "pluginVersion": "0.5.2",
+      "pluginVersion": "1.0.0",
       "targets": [
         {
           "datasource": {
@@ -250,11 +259,215 @@
       "gridPos": {
         "h": 12,
         "w": 3,
-        "x": 10,
+        "x": 9,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "customColors": {
+          "enabled": false
+        },
+        "horizontal": false,
+        "layoutMode": "grid",
+        "minLightWidth": 75,
+        "reverseColors": false,
+        "seriesCountSize": "sm",
+        "showLegend": false,
+        "showSeriesCount": false,
+        "showTrend": false,
+        "showValue": false,
+        "singleRow": false,
+        "sortLights": "none",
+        "style": "default",
+        "text": "Default value of text input option"
+      },
+      "pluginVersion": "1.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "testdata"
+          },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "seriesCount": 1
+        }
+      ],
+      "title": "Traffic Light (default)",
+      "type": "heywesty-trafficlight-panel"
+    },
+    {
+      "datasource": {
+        "type": "testdata",
+        "uid": "P814D78962B0F8AC2"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 33
+              },
+              {
+                "color": "green",
+                "value": 66
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 3,
+        "x": 12,
+        "y": 0
+      },
+      "id": 28,
+      "options": {
+        "customColors": {
+          "enabled": false
+        },
+        "horizontal": false,
+        "layoutMode": "grid",
+        "minLightWidth": 75,
+        "reverseColors": false,
+        "seriesCountSize": "sm",
+        "showLegend": false,
+        "showSeriesCount": false,
+        "showTrend": false,
+        "showValue": false,
+        "singleRow": false,
+        "sortLights": "none",
+        "style": "rounded",
+        "text": "Default value of text input option"
+      },
+      "pluginVersion": "1.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "testdata"
+          },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "seriesCount": 1
+        }
+      ],
+      "title": "Traffic Light (rounded)",
+      "type": "heywesty-trafficlight-panel"
+    },
+    {
+      "datasource": {
+        "type": "testdata",
+        "uid": "P814D78962B0F8AC2"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 33
+              },
+              {
+                "color": "green",
+                "value": 66
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 3,
+        "x": 15,
+        "y": 0
+      },
+      "id": 29,
+      "options": {
+        "customColors": {
+          "enabled": false
+        },
+        "horizontal": false,
+        "layoutMode": "grid",
+        "minLightWidth": 75,
+        "reverseColors": false,
+        "seriesCountSize": "sm",
+        "showLegend": false,
+        "showSeriesCount": false,
+        "showTrend": false,
+        "showValue": false,
+        "singleRow": false,
+        "sortLights": "none",
+        "style": "sidelights",
+        "text": "Default value of text input option"
+      },
+      "pluginVersion": "1.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "testdata"
+          },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "seriesCount": 1
+        }
+      ],
+      "title": "Traffic Light (sidelights)",
+      "type": "heywesty-trafficlight-panel"
+    },
+    {
+      "datasource": {
+        "type": "testdata",
+        "uid": "P814D78962B0F8AC2"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 33
+              },
+              {
+                "color": "green",
+                "value": 66
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 3,
+        "x": 18,
         "y": 0
       },
       "id": 22,
       "options": {
+        "customColors": {
+          "enabled": false
+        },
         "horizontal": false,
         "layoutMode": "grid",
         "minLightWidth": 75,
@@ -269,7 +482,7 @@
         "style": "dynamic",
         "text": "Default value of text input option"
       },
-      "pluginVersion": "0.5.2",
+      "pluginVersion": "1.0.0",
       "targets": [
         {
           "datasource": {
@@ -281,6 +494,150 @@
         }
       ],
       "title": "Traffic Light (dynamic)",
+      "type": "heywesty-trafficlight-panel"
+    },
+    {
+      "datasource": {
+        "type": "testdata",
+        "uid": "P814D78962B0F8AC2"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "purple",
+                "value": 33
+              },
+              {
+                "color": "#6ED0E0",
+                "value": 66
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Machine Running"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Operator Required"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Number of Faults"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 100
+                    },
+                    {
+                      "color": "blue",
+                      "value": 200
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 3,
+        "x": 21,
+        "y": 0
+      },
+      "id": 25,
+      "options": {
+        "customColors": {
+          "enabled": false
+        },
+        "horizontal": false,
+        "layoutMode": "grid",
+        "minLightWidth": 75,
+        "reverseColors": false,
+        "seriesCountSize": "sm",
+        "showLegend": true,
+        "showSeriesCount": false,
+        "showTrend": false,
+        "showValue": false,
+        "singleRow": false,
+        "sortLights": "none",
+        "style": "stacklight",
+        "text": "Default value of text input option"
+      },
+      "pluginVersion": "1.0.0",
+      "targets": [
+        {
+          "csvContent": "Time,Machine Running,Fault Active,Operator Required,Number of Faults\n2024-01-01T00:00:00Z,1,0,1,200",
+          "datasource": {
+            "type": "testdata"
+          },
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Traffic Light (stacked)",
       "type": "heywesty-trafficlight-panel"
     },
     {
@@ -313,12 +670,15 @@
       },
       "gridPos": {
         "h": 12,
-        "w": 11,
-        "x": 13,
-        "y": 0
+        "w": 12,
+        "x": 0,
+        "y": 12
       },
       "id": 7,
       "options": {
+        "customColors": {
+          "enabled": false
+        },
         "horizontal": false,
         "layoutMode": "grid",
         "minLightWidth": 100,
@@ -333,7 +693,7 @@
         "style": "default",
         "text": "Default value of text input option"
       },
-      "pluginVersion": "0.5.2",
+      "pluginVersion": "1.0.0",
       "targets": [
         {
           "datasource": {
@@ -379,13 +739,16 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
+        "h": 12,
+        "w": 12,
+        "x": 12,
         "y": 12
       },
       "id": 9,
       "options": {
+        "customColors": {
+          "enabled": false
+        },
         "horizontal": false,
         "layoutMode": "row",
         "minLightWidth": 100,
@@ -396,71 +759,7 @@
         "sortLights": "none",
         "style": "default"
       },
-      "pluginVersion": "0.5.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "testdata",
-            "uid": "P814D78962B0F8AC2"
-          },
-          "refId": "A",
-          "scenarioId": "random_walk",
-          "seriesCount": 20
-        }
-      ],
-      "title": "Traffic Light single row layout",
-      "type": "heywesty-trafficlight-panel"
-    },
-    {
-      "datasource": {
-        "type": "testdata",
-        "uid": "P814D78962B0F8AC2"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "percentage",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 50
-              },
-              {
-                "color": "#73BF69",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
-        "y": 21
-      },
-      "id": 24,
-      "options": {
-        "horizontal": false,
-        "layoutMode": "marquee",
-        "minLightWidth": 100,
-        "reverseColors": false,
-        "showLegend": true,
-        "showTrend": true,
-        "showValue": true,
-        "sortLights": "none",
-        "style": "default"
-      },
-      "pluginVersion": "0.5.2",
+      "pluginVersion": "1.0.0",
       "targets": [
         {
           "datasource": {
@@ -510,10 +809,13 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 30
+        "y": 24
       },
       "id": 15,
       "options": {
+        "customColors": {
+          "enabled": false
+        },
         "horizontal": true,
         "layoutMode": "grid",
         "minLightWidth": 100,
@@ -525,7 +827,7 @@
         "sortLights": "none",
         "style": "default"
       },
-      "pluginVersion": "0.5.2",
+      "pluginVersion": "1.0.0",
       "targets": [
         {
           "datasource": {
@@ -575,10 +877,13 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 30
+        "y": 24
       },
       "id": 18,
       "options": {
+        "customColors": {
+          "enabled": false
+        },
         "horizontal": true,
         "layoutMode": "row",
         "minLightWidth": 100,
@@ -589,7 +894,7 @@
         "sortLights": "none",
         "style": "default"
       },
-      "pluginVersion": "0.5.2",
+      "pluginVersion": "1.0.0",
       "targets": [
         {
           "datasource": {
@@ -619,7 +924,8 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "red"
+                "color": "red",
+                "value": null
               },
               {
                 "color": "#EAB839",
@@ -638,11 +944,15 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 39
+        "y": 33
       },
       "id": 19,
       "options": {
+        "customColors": {
+          "enabled": false
+        },
         "horizontal": false,
+        "layoutMode": "Grid",
         "minLightWidth": 100,
         "reverseColors": true,
         "showLegend": true,
@@ -652,6 +962,7 @@
         "sortLights": "none",
         "style": "default"
       },
+      "pluginVersion": "1.0.0",
       "targets": [
         {
           "datasource": {
@@ -681,7 +992,8 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "red"
+                "color": "red",
+                "value": null
               },
               {
                 "color": "#EAB839",
@@ -700,20 +1012,24 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 39
+        "y": 33
       },
       "id": 20,
       "options": {
+        "customColors": {
+          "enabled": false
+        },
         "horizontal": false,
+        "layoutMode": "row",
         "minLightWidth": 100,
         "reverseColors": false,
         "showLegend": true,
         "showTrend": true,
         "showValue": true,
-        "singleRow": true,
         "sortLights": "none",
         "style": "default"
       },
+      "pluginVersion": "1.0.0",
       "targets": [
         {
           "csvContent": "time, value\n100000000, 1",
@@ -758,7 +1074,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red"
+                "color": "red",
+                "value": null
               },
               {
                 "color": "#EAB839",
@@ -777,20 +1094,24 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 48
+        "y": 42
       },
       "id": 21,
       "options": {
+        "customColors": {
+          "enabled": false
+        },
         "horizontal": false,
+        "layoutMode": "row",
         "minLightWidth": 100,
         "reverseColors": false,
         "showLegend": true,
         "showTrend": true,
         "showValue": true,
-        "singleRow": true,
         "sortLights": "none",
         "style": "default"
       },
+      "pluginVersion": "1.0.0",
       "targets": [
         {
           "csvContent": "\"Name\",\"Value\"\n\"Blob Storage\", 1\n\"Exported Storage\", 4\n\"Hangfire\", 3\n\"Imported Storage\", 5\n\"SQL server db\", 1",
@@ -826,7 +1147,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "#EAB839",
@@ -845,11 +1167,15 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 48
+        "y": 42
       },
       "id": 23,
       "options": {
+        "customColors": {
+          "enabled": false
+        },
         "horizontal": false,
+        "layoutMode": "Grid",
         "minLightWidth": 100,
         "reverseColors": false,
         "showLegend": true,
@@ -859,6 +1185,7 @@
         "sortLights": "none",
         "style": "default"
       },
+      "pluginVersion": "1.0.0",
       "targets": [
         {
           "alias": "",
@@ -889,7 +1216,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -904,11 +1232,15 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 55
+        "y": 49
       },
       "id": 10,
       "options": {
+        "customColors": {
+          "enabled": false
+        },
         "horizontal": false,
+        "layoutMode": "Grid",
         "minLightWidth": 75,
         "reverseColors": false,
         "showLegend": true,
@@ -918,6 +1250,7 @@
         "sortLights": "none",
         "style": "default"
       },
+      "pluginVersion": "1.0.0",
       "title": "Traffic Light incorrect thresholds",
       "type": "heywesty-trafficlight-panel"
     },
@@ -936,7 +1269,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -949,13 +1283,17 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
+        "w": 5,
         "x": 8,
-        "y": 55
+        "y": 49
       },
       "id": 13,
       "options": {
+        "customColors": {
+          "enabled": false
+        },
         "horizontal": false,
+        "layoutMode": "Grid",
         "minLightWidth": 75,
         "reverseColors": false,
         "showLegend": true,
@@ -965,6 +1303,7 @@
         "sortLights": "none",
         "style": "default"
       },
+      "pluginVersion": "1.0.0",
       "targets": [
         {
           "datasource": {
@@ -994,7 +1333,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1007,13 +1347,17 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 55
+        "w": 5,
+        "x": 13,
+        "y": 49
       },
       "id": 14,
       "options": {
+        "customColors": {
+          "enabled": false
+        },
         "horizontal": false,
+        "layoutMode": "Grid",
         "minLightWidth": 75,
         "reverseColors": false,
         "showLegend": true,
@@ -1023,6 +1367,7 @@
         "sortLights": "none",
         "style": "default"
       },
+      "pluginVersion": "1.0.0",
       "targets": [
         {
           "csvContent": "time, value\n10000000000, 'a'",
@@ -1034,7 +1379,75 @@
           "scenarioId": "csv_content"
         }
       ],
-      "title": "Traffic Light no data",
+      "title": "Traffic Light unsupported format",
+      "type": "heywesty-trafficlight-panel"
+    },
+    {
+      "datasource": {
+        "type": "testdata",
+        "uid": "P814D78962B0F8AC2"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "noValue": "100",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 50
+              },
+              {
+                "color": "#73BF69",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 49
+      },
+      "id": 30,
+      "options": {
+        "customColors": {
+          "enabled": false
+        },
+        "horizontal": false,
+        "layoutMode": "row",
+        "minLightWidth": 100,
+        "reverseColors": false,
+        "showLegend": true,
+        "showTrend": true,
+        "showValue": true,
+        "sortLights": "none",
+        "style": "default"
+      },
+      "pluginVersion": "1.0.0",
+      "targets": [
+        {
+          "csvContent": "time, value\n100000000, \"\"",
+          "datasource": {
+            "type": "testdata",
+            "uid": "P814D78962B0F8AC2"
+          },
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Traffic Light no value",
       "type": "heywesty-trafficlight-panel"
     },
     {
@@ -1052,7 +1465,8 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "red"
+                "color": "red",
+                "value": null
               },
               {
                 "color": "red",
@@ -1083,7 +1497,8 @@
                   "mode": "percentage",
                   "steps": [
                     {
-                      "color": "super-light-red"
+                      "color": "super-light-red",
+                      "value": null
                     },
                     {
                       "color": "red",
@@ -1110,7 +1525,8 @@
                   "mode": "percentage",
                   "steps": [
                     {
-                      "color": "super-light-orange"
+                      "color": "super-light-orange",
+                      "value": null
                     },
                     {
                       "color": "orange",
@@ -1137,7 +1553,8 @@
                   "mode": "percentage",
                   "steps": [
                     {
-                      "color": "super-light-yellow"
+                      "color": "super-light-yellow",
+                      "value": null
                     },
                     {
                       "color": "yellow",
@@ -1164,7 +1581,8 @@
                   "mode": "percentage",
                   "steps": [
                     {
-                      "color": "super-light-green"
+                      "color": "super-light-green",
+                      "value": null
                     },
                     {
                       "color": "green",
@@ -1191,7 +1609,8 @@
                   "mode": "percentage",
                   "steps": [
                     {
-                      "color": "super-light-blue"
+                      "color": "super-light-blue",
+                      "value": null
                     },
                     {
                       "color": "blue",
@@ -1218,7 +1637,8 @@
                   "mode": "percentage",
                   "steps": [
                     {
-                      "color": "super-light-purple"
+                      "color": "super-light-purple",
+                      "value": null
                     },
                     {
                       "color": "purple",
@@ -1239,11 +1659,15 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 63
+        "y": 57
       },
       "id": 16,
       "options": {
+        "customColors": {
+          "enabled": false
+        },
         "horizontal": false,
+        "layoutMode": "Grid",
         "minLightWidth": 100,
         "reverseColors": false,
         "showLegend": true,
@@ -1253,6 +1677,7 @@
         "sortLights": "none",
         "style": "default"
       },
+      "pluginVersion": "1.0.0",
       "targets": [
         {
           "datasource": {
@@ -1294,7 +1719,8 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "red"
+                "color": "red",
+                "value": null
               },
               {
                 "color": "#EAB839",
@@ -1338,11 +1764,15 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 63
+        "y": 57
       },
       "id": 17,
       "options": {
+        "customColors": {
+          "enabled": false
+        },
         "horizontal": false,
+        "layoutMode": "Grid",
         "minLightWidth": 100,
         "reverseColors": false,
         "showLegend": true,
@@ -1352,6 +1782,7 @@
         "sortLights": "none",
         "style": "default"
       },
+      "pluginVersion": "1.0.0",
       "targets": [
         {
           "datasource": {

--- a/src/README.md
+++ b/src/README.md
@@ -19,7 +19,7 @@ Grafana >=9.5.3
 - **Value Display:** Option to show or hide the values associated with each light.
 - **Legend Display:** Option to show or hide the legend (query name) associated with each light.
 - **Trend Display:** Show or hide the trend color to provide an additional layer of information.
-- **Traffic Light Style:** Pick a style of traffic light. If you want a custom number of lights use dynamic.
+- **Traffic Light Style:** Pick a style of traffic light. Dynamic lets you set any number of lights using thresholds. Stack light renders one segment per data field, with each segment independently on or off.
 - **Orientation Flexibility:** Choose between a vertical or horizontal layout for the traffic lights.
 
 ## Installation
@@ -34,7 +34,7 @@ This plugin can be installed using one of the following methods:
 
 The traffic light panel uses the built in Grafana thresholds to assign lights to values.
 
-1. **Choose a traffic light style:** In the panel settings, select a light style. Dynamic allows you to add any number of lights based on the threshold settings. All other light styles require 3 thresholds to be set.
+1. **Choose a traffic light style:** In the panel settings, select a light style. Dynamic allows you to add any number of lights based on threshold settings. Stack light uses one data field per segment — each segment is on or off based on whether its field's value crosses a threshold. All other styles require at least three thresholds.
 2. **Define Thresholds:** In the panel settings, define thresholds that categorize your data. A basic thresholds example for a traffic light looks like:
 
    <img width="300px" src="https://raw.githubusercontent.com/jackw/heywesty-trafficlight-panel/main/docs/thresholds-example.png" />
@@ -54,9 +54,9 @@ Getting started is as simple as adding the panel to your dashboard and tweaking 
 1. **Single Row View:** By default each light will flow in an auto grid layout. This can be controlled by adjusting the minimum light width. Enable this if you'd prefer to keep all lights on one row.
 1. **Reverse Light Color:** Due to Grafana auto sorting thresholds, this option caters for situations where the "base" threshold should be considered "go" and the highest threshold should be considered "stop".
 1. **Show Value:** Choose whether to display the numerical values with each light. True by default.
-1. **Show Legend:** Choose whether to display the numerical values with each light. True by default.
+1. **Show Legend:** Choose whether to display the query name (legend) with each light. True by default.
 1. **Show Trend:** Add an extra layer of insight with a trend color. True by default.
-1. **Traffic Light Style:** Choose from one of: default, rounded, side lights, or dynamic.
+1. **Traffic Light Style:** Choose from one of: default, rounded, side lights, dynamic, or stack light.
 1. **Sort Lights:** Organize your traffic lights in the order that makes sense to you:
    - None: Keep data series order.
    - Ascending: Line them up from lowest to highest values.
@@ -75,4 +75,4 @@ The plugin supports any data source that returns data frame(s) containing one nu
 
 ### Thresholds are incorrectly set.
 
-Thresholds need to be set for the plugin to operate. Please see [usage](#usage) section above. Thresholds must contain `base` and two other values. One for each light.
+Thresholds need to be set for the plugin to operate. Refer to the [usage](#usage) section above. Most styles require a base threshold plus at least two others (one per light). Stack light requires only a base threshold and one trigger threshold per field.

--- a/src/components/TrafficLight.tsx
+++ b/src/components/TrafficLight.tsx
@@ -3,10 +3,12 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { DataLinksContextMenu, useTheme2 } from '@grafana/ui';
 import React from 'react';
 
-import { DEFAULT_CUSTOM_COLORS, LAYOUT_MODES } from '../constants';
+import { DEFAULT_CUSTOM_COLORS, LAYOUT_MODES, TRAFFIC_LIGHT_STYLES } from '../constants';
 import { CustomColorOptions, LayoutMode, LightsDataValues, TrafficLightStyle } from '../types';
 import { TrafficLightsComponentMap } from './TrafficLightStylesLazy';
 import { TrafficLightValue } from './TrafficLightValue';
+
+type PerLightStyle = Exclude<TrafficLightStyle, typeof TRAFFIC_LIGHT_STYLES.StackLight>;
 
 export function TrafficLight({
   light,
@@ -20,7 +22,7 @@ export function TrafficLight({
   customColors,
 }: {
   light: LightsDataValues;
-  style: TrafficLightStyle;
+  style: PerLightStyle;
   showLegend: boolean;
   showValue: boolean;
   showTrend: boolean;

--- a/src/components/TrafficLightPanel.tsx
+++ b/src/components/TrafficLightPanel.tsx
@@ -4,11 +4,12 @@ import { useLightsData } from 'hooks/useLightsData';
 import React, { lazy, Suspense } from 'react';
 import { calculateRowsAndColumns } from 'utils/utils';
 
-import { LAYOUT_MODES, LIGHTS_DATA_RESULT_STATUSES, TEST_IDS } from '../constants';
+import { LAYOUT_MODES, LIGHTS_DATA_RESULT_STATUSES, TRAFFIC_LIGHT_STYLES, TEST_IDS } from '../constants';
 import { LayoutMode, TrafficLightFeedbackProps, TrafficLightOptions } from '../types';
 import { TrafficLight } from './TrafficLight';
 
 const LazyTrafficLightFeedback = lazy(() => import('./TrafficLightFeedback'));
+const LazyTrafficLightStackLight = lazy(() => import('./TrafficLightStackLight'));
 
 const TrafficLightFeedback = (props: TrafficLightFeedbackProps) => (
   <Suspense fallback={null}>
@@ -54,6 +55,16 @@ export function TrafficLightPanel({
 
   if (status !== LIGHTS_DATA_RESULT_STATUSES.Success) {
     return <TrafficLightFeedback status={status} invalidThresholds={invalidThresholds} style={style} />;
+  }
+
+  if (style === TRAFFIC_LIGHT_STYLES.StackLight) {
+    return (
+      <div style={{ width, height }} data-testid={TEST_IDS.trafficLight}>
+        <Suspense fallback={null}>
+          <LazyTrafficLightStackLight values={values} customColors={customColors} horizontal={horizontal} />
+        </Suspense>
+      </div>
+    );
   }
 
   return (

--- a/src/components/TrafficLightPanel.tsx
+++ b/src/components/TrafficLightPanel.tsx
@@ -2,10 +2,10 @@ import { css } from '@emotion/css';
 import { PanelProps } from '@grafana/data';
 import { useLightsData } from 'hooks/useLightsData';
 import React, { lazy, Suspense } from 'react';
-import { calculateRowsAndColumns } from 'utils/utils';
 
-import { LAYOUT_MODES, LIGHTS_DATA_RESULT_STATUSES, TRAFFIC_LIGHT_STYLES, TEST_IDS } from '../constants';
+import { LAYOUT_MODES, LIGHTS_DATA_RESULT_STATUSES, TEST_IDS, TRAFFIC_LIGHT_STYLES } from '../constants';
 import { LayoutMode, TrafficLightFeedbackProps, TrafficLightOptions } from '../types';
+import { calculateRowsAndColumns } from '../utils/utils';
 import { TrafficLight } from './TrafficLight';
 
 const LazyTrafficLightFeedback = lazy(() => import('./TrafficLightFeedback'));

--- a/src/components/TrafficLightPanel.tsx
+++ b/src/components/TrafficLightPanel.tsx
@@ -53,11 +53,10 @@ export function TrafficLightPanel({
   const { rows, cols } = calculateRowsAndColumns(width, minLightWidth, values.length);
   const containerStyle = getStyles({ rows, cols, layoutMode, minLightWidth });
 
-  if (status !== LIGHTS_DATA_RESULT_STATUSES.Success) {
-    return <TrafficLightFeedback status={status} invalidThresholds={invalidThresholds} style={style} />;
-  }
-
   if (style === TRAFFIC_LIGHT_STYLES.StackLight) {
+    if (status === LIGHTS_DATA_RESULT_STATUSES.NoData || status === LIGHTS_DATA_RESULT_STATUSES.Unsupported) {
+      return <TrafficLightFeedback status={status} invalidThresholds={invalidThresholds} style={style} />;
+    }
     return (
       <div style={{ width, height }} data-testid={TEST_IDS.trafficLight}>
         <Suspense fallback={null}>
@@ -65,6 +64,10 @@ export function TrafficLightPanel({
         </Suspense>
       </div>
     );
+  }
+
+  if (status !== LIGHTS_DATA_RESULT_STATUSES.Success) {
+    return <TrafficLightFeedback status={status} invalidThresholds={invalidThresholds} style={style} />;
   }
 
   return (

--- a/src/components/TrafficLightStackLight.tsx
+++ b/src/components/TrafficLightStackLight.tsx
@@ -1,6 +1,7 @@
 import { GrafanaTheme2 } from '@grafana/data';
 import { useTheme2 } from '@grafana/ui';
 import React from 'react';
+
 import { DEFAULT_CUSTOM_COLORS, TEST_IDS } from '../constants';
 import { CustomColorOptions, LightsDataValues } from '../types';
 import { clamp } from '../utils/utils';
@@ -48,7 +49,7 @@ export default function TrafficLightStackLight({
           const activeIndex = value.colors.findIndex((c) => c.active);
           // colors[0] is always the base threshold (−∞); any higher index means a trigger threshold is active
           const isOn = activeIndex > 0;
-          const segmentColor = isOn ? (value.colors[activeIndex]?.color ?? emptyColor) : emptyColor;
+          const segmentColor = isOn ? value.colors[activeIndex]?.color ?? emptyColor : emptyColor;
 
           return (
             <g key={index}>

--- a/src/components/TrafficLightStackLight.tsx
+++ b/src/components/TrafficLightStackLight.tsx
@@ -45,7 +45,10 @@ export default function TrafficLightStackLight({
         />
 
         {values.map((value, index) => {
-          const segmentColor = value.colors.find((c) => c.active)?.color ?? emptyColor;
+          const activeIndex = value.colors.findIndex((c) => c.active);
+          // colors[0] is always the base threshold (−∞); any higher index means a trigger threshold is active
+          const isOn = activeIndex > 0;
+          const segmentColor = isOn ? (value.colors[activeIndex]?.color ?? emptyColor) : emptyColor;
 
           return (
             <g key={index}>
@@ -56,7 +59,7 @@ export default function TrafficLightStackLight({
                 height={height}
                 rx="8"
                 fill={segmentColor}
-                style={{ filter: `drop-shadow(0 0 16px ${segmentColor})` }}
+                style={isOn ? { filter: `drop-shadow(0 0 16px ${segmentColor})` } : {}}
               />
             </g>
           );

--- a/src/components/TrafficLightStackLight.tsx
+++ b/src/components/TrafficLightStackLight.tsx
@@ -1,0 +1,115 @@
+import { GrafanaTheme2 } from '@grafana/data';
+import { useTheme2 } from '@grafana/ui';
+import React from 'react';
+import { DEFAULT_CUSTOM_COLORS, TEST_IDS } from '../constants';
+import { CustomColorOptions, LightsDataValues } from '../types';
+import { clamp } from '../utils/utils';
+
+interface TrafficLightStackLightProps {
+  values: LightsDataValues[];
+  customColors?: CustomColorOptions;
+  horizontal?: boolean;
+}
+
+export default function TrafficLightStackLight({
+  values,
+  customColors,
+  horizontal = false,
+}: TrafficLightStackLightProps) {
+  const theme = useTheme2();
+  const bgColor = getBackgroundColor(customColors, theme);
+  const emptyColor = getEmptyLightColor(customColors, theme);
+
+  const totalAvailableHeight = 406;
+  const minGap = 4;
+  const maxGap = 24;
+  const numberOfSegments = values.length;
+  const x = 52;
+  const segmentWidth = 168;
+  const { height, yPosition } = calculateSegmentPositions(totalAvailableHeight, minGap, maxGap, numberOfSegments);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox={horizontal ? '0 0 512 272' : '0 0 272 512'}
+      style={{ height: '100%', width: '100%' }}
+      data-testid={TEST_IDS.styleStackLight}
+    >
+      <g transform={horizontal ? 'rotate(-90 0 0)' : undefined} style={{ transformOrigin: '25% center' }}>
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M46 13C34.9543 13 26 21.9543 26 33V479.095C26 490.141 34.9543 499.095 46 499.095H226C237.046 499.095 246 490.141 246 479.095V33C246 21.9543 237.046 13 226 13H46Z"
+          fill={bgColor}
+        />
+
+        {values.map((value, index) => {
+          const segmentColor = value.colors.find((c) => c.active)?.color ?? emptyColor;
+
+          return (
+            <g key={index}>
+              <rect
+                x={x}
+                y={yPosition[index]}
+                width={segmentWidth}
+                height={height}
+                rx="8"
+                fill={segmentColor}
+                style={{ filter: `drop-shadow(0 0 16px ${segmentColor})` }}
+              />
+            </g>
+          );
+        })}
+      </g>
+    </svg>
+  );
+}
+
+function calculateSegmentPositions(
+  totalHeight: number,
+  minGap: number,
+  maxGap: number,
+  numberOfSegments: number,
+  startOffset = 57
+) {
+  const numGaps = numberOfSegments - 1;
+  const initialGapSize = maxGap / (numberOfSegments * 0.5);
+  const gapSize = clamp(initialGapSize, minGap, maxGap);
+  const totalGapHeight = gapSize * numGaps;
+  const remainingHeightForSegments = totalHeight - totalGapHeight;
+  const segmentHeight = remainingHeightForSegments / numberOfSegments;
+
+  let currentYPosition = startOffset;
+  const yPositions: number[] = [];
+
+  for (let i = 0; i < numberOfSegments; i++) {
+    yPositions.push(currentYPosition);
+    currentYPosition += segmentHeight + gapSize;
+  }
+
+  return {
+    height: segmentHeight,
+    yPosition: yPositions,
+  };
+}
+
+function getBackgroundColor(customColors: CustomColorOptions | undefined, theme: GrafanaTheme2): string {
+  if (customColors?.enabled) {
+    const color = theme.isDark
+      ? customColors.darkBackgroundColor ?? DEFAULT_CUSTOM_COLORS.darkBackground
+      : customColors.lightBackgroundColor ?? DEFAULT_CUSTOM_COLORS.lightBackground;
+    return theme.visualization.getColorByName(color);
+  }
+  return theme.isDark ? theme.colors.background.secondary : DEFAULT_CUSTOM_COLORS.lightBackground;
+}
+
+function getEmptyLightColor(customColors: CustomColorOptions | undefined, theme: GrafanaTheme2): string {
+  if (customColors?.enabled) {
+    const color = theme.isDark
+      ? customColors.darkEmptyColor ?? DEFAULT_CUSTOM_COLORS.darkEmpty
+      : customColors.lightEmptyColor ?? DEFAULT_CUSTOM_COLORS.lightEmpty;
+    return theme.visualization.getColorByName(color);
+  }
+  return theme.isDark ? theme.colors.background.primary : DEFAULT_CUSTOM_COLORS.lightEmpty;
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,6 +13,7 @@ export const TEST_IDS = {
   styleRounded: 'traffic-light-style-rounded',
   styleSidelights: 'traffic-light-style-sidelights',
   styleDynamic: 'traffic-light-style-dynamic',
+  styleStackLight: 'traffic-light-style-stacklight',
 };
 
 const EMPTY_VALUE: LightsDataValues = {
@@ -53,6 +54,7 @@ export const TRAFFIC_LIGHT_STYLES = {
   Rounded: 'rounded',
   SideLights: 'sidelights',
   Dynamic: 'dynamic',
+  StackLight: 'stacklight',
 } as const;
 
 export const DEFAULT_CUSTOM_COLORS = {

--- a/tests/stack-light.spec.ts
+++ b/tests/stack-light.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from '@grafana/plugin-e2e';
+import { gte } from 'semver';
+
+import { TEST_IDS } from '../src/constants';
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe('Traffic Light Stack Light', () => {
+  test.beforeEach(async ({ panelEditPage, page, selectors }) => {
+    await panelEditPage.setVisualization('Traffic Light');
+    await page.getByRole('button', { name: /add Threshold/i }).click();
+    await panelEditPage.getQueryEditorRow('A').getByText('Scenario').click();
+    await page.keyboard.insertText('CSV Content');
+    await page.keyboard.press('Enter');
+    await page.waitForFunction(() => (window as any).monaco);
+    await panelEditPage.getByGrafanaSelector(selectors.components.CodeEditor.container).click();
+    await page.keyboard.insertText(`time,Running\n10000000000,100`);
+    await panelEditPage.getCustomOptions('Traffic Light').getSelect('Traffic light style').selectOption('Stack light');
+    await panelEditPage.refreshPanel();
+  });
+
+  test('renders the stack light SVG', async ({ page }) => {
+    const trafficLightPanel = page.getByTestId(TEST_IDS.trafficLight);
+    await expect(trafficLightPanel.getByTestId(TEST_IDS.styleStackLight)).toBeVisible();
+  });
+
+  test('renders one segment per field', async ({ panelEditPage, page, selectors }) => {
+    await panelEditPage.getByGrafanaSelector(selectors.components.CodeEditor.container).click();
+    await page.keyboard.press('Control+A');
+    await page.keyboard.press('Backspace');
+    await page.keyboard.insertText(`time,Field A,Field B,Field C\n10000000000,100,100,100`);
+    await panelEditPage.refreshPanel();
+
+    const svg = page.getByTestId(TEST_IDS.trafficLight).getByTestId(TEST_IDS.styleStackLight);
+    await expect(svg.locator('rect')).toHaveCount(3);
+  });
+
+  test('segment glows when value crosses trigger threshold', async ({ page }) => {
+    const svg = page.getByTestId(TEST_IDS.trafficLight).getByTestId(TEST_IDS.styleStackLight);
+    const segment = svg.locator('rect').first();
+    await expect(segment).toHaveAttribute('style', /drop-shadow/);
+  });
+
+  test('segment is dim when value is below trigger threshold', async ({ panelEditPage, page, selectors }) => {
+    await panelEditPage.getByGrafanaSelector(selectors.components.CodeEditor.container).click();
+    await page.keyboard.press('Control+A');
+    await page.keyboard.press('Backspace');
+    await page.keyboard.insertText(`time,Running\n10000000000,0`);
+    await panelEditPage.refreshPanel();
+
+    const svg = page.getByTestId(TEST_IDS.trafficLight).getByTestId(TEST_IDS.styleStackLight);
+    const segment = svg.locator('rect').first();
+    await expect(segment).not.toHaveAttribute('style', /drop-shadow/);
+  });
+
+  test('renders with 2-step thresholds without IncorrectThresholds error', async ({ page }) => {
+    await expect(page.getByTestId(TEST_IDS.trafficLight)).toBeVisible();
+    await expect(page.getByTestId(TEST_IDS.feedbackMsgContainer)).not.toBeVisible();
+  });
+
+  test('horizontal orientation changes SVG viewBox', async ({ panelEditPage, page, selectors, grafanaVersion }) => {
+    const horizontalSwitchLabel = panelEditPage.getByGrafanaSelector(
+      selectors.components.PanelEditor.OptionsPane.fieldLabel('Traffic Light Horizontal traffic lights')
+    );
+    const horizontalSwitch = gte(grafanaVersion, '11.5.0')
+      ? horizontalSwitchLabel.getByRole('switch')
+      : horizontalSwitchLabel.getByLabel('Toggle switch');
+
+    await horizontalSwitch.click({ force: true });
+
+    const svg = page.getByTestId(TEST_IDS.trafficLight).getByTestId(TEST_IDS.styleStackLight);
+    await expect(svg).toHaveAttribute('viewBox', '0 0 512 272');
+
+    await horizontalSwitch.click({ force: true });
+    await expect(svg).toHaveAttribute('viewBox', '0 0 272 512');
+  });
+});


### PR DESCRIPTION
Closes #33

## Summary

- Adds a new **stack light** style that renders a single tower with one segment per data field — any combination of segments can be active simultaneously, matching real industrial stack light behaviour
- Each segment is binary on/off: the base threshold = OFF (emptyColor), any non-base threshold active = ON with that threshold's colour
- Stack light bypasses the 3-step threshold minimum, allowing simple 2-step (base + trigger) per field
- Updates `src/README.md` with stack light documentation and fixes a copy-paste error in the Show Legend description
- Adds a stack light panel to the provisioning dashboard

## How it works

Each field drives one segment independently. Use the TestData DB CSV content scenario to test:

```
Time,Machine Running,Fault Active,Operator Required
2024-01-01T00:00:00Z,1,0,1
```

Set a threshold per field via **Field overrides** (base = off, one trigger threshold = on colour). Fields with value `1` light up; fields with value `0` stay dim.

## Test plan

- [ ] Select "Stack light" style — tower renders with one segment per field
- [ ] Field value below trigger threshold → segment is dim (OFF)
- [ ] Field value above trigger threshold → segment glows with configured colour (ON)
- [ ] Multiple fields with different on-colours work independently
- [ ] Horizontal orientation works
- [ ] Panel with fewer than 3 threshold steps renders correctly (no IncorrectThresholds error)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)